### PR TITLE
CDRIVER-3638 add non-locking variant of `_mongoc_handshake_freeze` (#…

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-handshake.c
+++ b/src/libmongoc/src/mongoc/mongoc-handshake.c
@@ -725,6 +725,12 @@ _mongoc_handshake_freeze (void)
    bson_mutex_unlock (&gHandshakeLock);
 }
 
+static void
+_mongoc_handshake_freeze_nolock (void)
+{
+   _mongoc_handshake_get ()->frozen = true;
+}
+
 /*
  * free (*s) and make *s point to *s concated with suffix.
  * If *s is NULL it's treated like it's an empty string.
@@ -804,7 +810,7 @@ mongoc_handshake_data_append (const char *driver_name, const char *driver_versio
       _append_and_truncate (&_mongoc_handshake_get ()->driver_version, driver_version, HANDSHAKE_DRIVER_VERSION_MAX);
    }
 
-   _mongoc_handshake_freeze ();
+   _mongoc_handshake_freeze_nolock ();
    bson_mutex_unlock (&gHandshakeLock);
 
    return true;


### PR DESCRIPTION
…1701)

Fixes recursive lock in `mongoc_handshake_data_append`